### PR TITLE
Implement admin login

### DIFF
--- a/app/Http/Controllers/admin/AdminAuthController.php
+++ b/app/Http/Controllers/admin/AdminAuthController.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Http\Controllers\admin;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+
+class AdminAuthController extends Controller
+{
+    public function showLoginForm()
+    {
+        return view('admin.login');
+    }
+
+    public function login(Request $request)
+    {
+        $credentials = $request->validate([
+            'email' => ['required', 'email'],
+            'password' => ['required', 'string'],
+        ]);
+
+        if (Auth::guard('admin')->attempt($credentials)) {
+            $request->session()->regenerate();
+            return redirect()->intended(route('admin.createwebinar.index'));
+        }
+
+        return back()->withErrors([
+            'email' => 'The provided credentials do not match our records.',
+        ])->onlyInput('email');
+    }
+
+    public function logout(Request $request)
+    {
+        Auth::guard('admin')->logout();
+
+        $request->session()->invalidate();
+        $request->session()->regenerateToken();
+
+        return redirect()->route('admin.login');
+    }
+}

--- a/app/Models/Admin.php
+++ b/app/Models/Admin.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Foundation\Auth\User as Authenticatable;
+use Illuminate\Notifications\Notifiable;
+
+class Admin extends Authenticatable
+{
+    use HasFactory, Notifiable;
+
+    protected $fillable = [
+        'email',
+        'password',
+    ];
+
+    protected $hidden = [
+        'password',
+        'remember_token',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'password' => 'hashed',
+        ];
+    }
+}

--- a/config/auth.php
+++ b/config/auth.php
@@ -40,6 +40,10 @@ return [
             'driver' => 'session',
             'provider' => 'users',
         ],
+        'admin' => [
+            'driver' => 'session',
+            'provider' => 'admins',
+        ],
     ],
 
     /*
@@ -63,6 +67,11 @@ return [
         'users' => [
             'driver' => 'eloquent',
             'model' => env('AUTH_MODEL', App\Models\User::class),
+        ],
+
+        'admins' => [
+            'driver' => 'eloquent',
+            'model' => App\Models\Admin::class,
         ],
 
         // 'users' => [

--- a/database/migrations/2025_06_17_093912_create_admins_table.php
+++ b/database/migrations/2025_06_17_093912_create_admins_table.php
@@ -13,6 +13,9 @@ return new class extends Migration
     {
         Schema::create('admins', function (Blueprint $table) {
             $table->id();
+            $table->string('email')->unique();
+            $table->string('password');
+            $table->rememberToken();
             $table->timestamps();
         });
     }

--- a/resources/views/admin/layouts/header.blade.php
+++ b/resources/views/admin/layouts/header.blade.php
@@ -68,7 +68,10 @@
                 <div class="dropdown-menu dropdown-menu-end dropdown-menu-arrow">
                     <a href="#" class="dropdown-item">Profile</a>
                     <a href="#" class="dropdown-item">Settings</a>
-                    <a href="#" class="dropdown-item">Logout</a>
+                    <form method="POST" action="{{ route('admin.logout') }}">
+                        @csrf
+                        <button type="submit" class="dropdown-item">Logout</button>
+                    </form>
                 </div>
             </div>
         </div>

--- a/resources/views/admin/login.blade.php
+++ b/resources/views/admin/login.blade.php
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Admin Login</title>
+    <link rel="stylesheet" href="{{ asset('admin/dist/css/login.css') }}">
+</head>
+<body>
+    <div id="loginSection">
+        <form method="POST" action="{{ route('admin.login.submit') }}" class="modern-form">
+            @csrf
+            <h2 class="form-title">Admin Login</h2>
+            <div class="input-group">
+                <div class="input-wrapper">
+                    <input type="email" name="email" class="form-input" placeholder="Email" value="{{ old('email') }}" required>
+                </div>
+            </div>
+            <div class="input-group">
+                <div class="input-wrapper">
+                    <input type="password" name="password" class="form-input" placeholder="Password" required>
+                </div>
+            </div>
+            <button type="submit" class="submit-button">Login<span class="button-glow"></span></button>
+            @if($errors->any())
+                <div class="form-footer" style="color:red;">{{ $errors->first('email') }}</div>
+            @endif
+        </form>
+    </div>
+</body>
+</html>

--- a/routes/web.php
+++ b/routes/web.php
@@ -4,6 +4,7 @@ use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\SubmissionController;
 use App\Http\Controllers\admin\Createwebinar;
 use App\Http\Controllers\admin\UserController;
+use App\Http\Controllers\admin\AdminAuthController;
 
 Route::view('/', 'welcome');
 
@@ -11,8 +12,13 @@ Route::view('/', 'welcome');
 Route::get('/form', [SubmissionController::class, 'create'])->name('submission.form');
 Route::post('/form', [SubmissionController::class, 'store'])->name('submission.store');
 
-// Admin routes
-Route::prefix('admin')->name('admin.')->group(function () {
+// Admin authentication
+Route::get('/admin/login', [AdminAuthController::class, 'showLoginForm'])->name('admin.login');
+Route::post('/admin/login', [AdminAuthController::class, 'login'])->name('admin.login.submit');
+Route::post('/admin/logout', [AdminAuthController::class, 'logout'])->name('admin.logout');
+
+// Protected admin routes
+Route::prefix('admin')->name('admin.')->middleware('auth:admin')->group(function () {
 
     // Webinar CRUD
     Route::resource('createwebinar', Createwebinar::class);


### PR DESCRIPTION
## Summary
- create `Admin` model for authentication
- add login routes and controller for admins
- secure admin routes with a new `auth:admin` guard
- style admin login page with existing assets
- update header to use a logout form
- extend `admins` table migration to store credentials

## Testing
- `php artisan test` *(fails: `php: command not found`)*
- `./vendor/bin/phpunit` *(fails: `No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_68513e01099883209708b12291b2b5cf